### PR TITLE
feat: Add blog page with search, filter, and SEO

### DIFF
--- a/src/app/blog/[slug]/layout.tsx
+++ b/src/app/blog/[slug]/layout.tsx
@@ -140,12 +140,12 @@ export async function generateMetadata(
 
 export default function BlogPostLayout({
   children,
-  params,
+  _params, // Prefixed with underscore
 }: {
   children: React.ReactNode;
-  params: { slug: string };
+  _params: any; // Changed type to any and prefixed
 }) {
-  // params can be used here if needed, e.g. for context providers
-  // console.log('Blog Post Layout Params:', params);
+  // _params can be used here if needed, e.g. for context providers
+  // console.log('Blog Post Layout Params:', _params);
   return <>{children}</>;
 }

--- a/src/app/blog/[slug]/layout.tsx
+++ b/src/app/blog/[slug]/layout.tsx
@@ -1,0 +1,147 @@
+import type { Metadata, ResolvingMetadata } from 'next';
+
+// Define the BlogPost interface and samplePostsDataForSlugPage array here
+// This data is needed for generateMetadata
+interface BlogPost {
+  id: string;
+  title: string;
+  description: string;
+  content: string; // Although not directly used by generateMetadata, it's part of the canonical BlogPost model
+  slug: string;
+  date: string;
+  category: string;
+  author?: string;
+  // imageUrl?: string; // If you plan to use images in OpenGraph metadata
+}
+
+const samplePostsDataForSlugPage: BlogPost[] = [
+  {
+    id: '1',
+    title: 'Getting Started with Next.js 14',
+    slug: 'getting-started-nextjs-14', // Matches slug in page.tsx postDisplayData
+    description: 'A beginner-friendly guide to setting up your first Next.js 14 application.',
+    content: `Next.js 14 introduces several exciting features... <br /><br /> Here's how to set up a new project: <br />\`npx create-next-app@latest\``,
+    date: '2024-03-10',
+    category: 'Technology',
+    author: 'Admin User',
+  },
+  {
+    id: '2',
+    title: 'Top 5 Travel Destinations for 2024',
+    slug: 'top-travel-destinations-2024', // Example, ensure slugs can match if needed
+    description: 'Explore breathtaking views and cultures with our top picks for your next vacation.',
+    content: 'From the serene beaches of Bali to the historic streets of Rome... <br /><br />1. Bali, Indonesia <br />2. Rome, Italy <br />3. Kyoto, Japan <br />4. Paris, France <br />5. Banff National Park, Canada',
+    date: '2024-03-12',
+    category: 'Travel',
+    author: 'Travel Blogger',
+  },
+  {
+    id: '3',
+    title: 'The Ultimate Guide to Delicious Homemade Pizza',
+    slug: 'homemade-pizza-guide', // Example
+    description: 'Learn how to make pizzeria-quality pizza in the comfort of your own kitchen.',
+    content: 'Crafting the perfect pizza at home is an art... <br /><br />Key ingredients: <br />- Dough <br />- Tomato Sauce <br />- Cheese <br />- Your favorite toppings',
+    date: '2024-03-15',
+    category: 'Food',
+    author: 'Chef G',
+  },
+  {
+    id: '4',
+    title: 'Understanding Cloud Computing',
+    slug: 'understanding-cloud-computing', // Example
+    description: 'A comprehensive overview of cloud computing models, services, and benefits.',
+    content: 'Cloud computing has revolutionized the way businesses operate... <br /><br />Models: IaaS, PaaS, SaaS. <br />Services: AWS, Azure, GCP.',
+    date: '2024-03-18',
+    category: 'Technology',
+    author: 'Tech Expert',
+  },
+  // Match slugs from the page component's postDisplayData for consistency if they should map 1:1
+  // For example, if page.tsx has a post with slug 'first-post', ensure it's here for metadata
+  {
+    id: '5', // New ID
+    title: 'My First Blog Post', // Title from page.tsx
+    slug: 'first-post', // Slug from page.tsx
+    description: 'This is the description for my first blog post about web development.', // Desc from page.tsx
+    content: 'Content for first post...', // Content can be brief here if only for page component
+    date: 'October 26, 2023', // Date from page.tsx
+    category: 'Technology', // Category from page.tsx
+    author: 'CertifyO Team',
+  },
+  {
+    id: '6',
+    title: 'Another Interesting Article',
+    slug: 'interesting-article',
+    description: 'A brief overview of an interesting topic in the world of travel.',
+    content: 'Content for another article...',
+    date: 'October 27, 2023',
+    category: 'Travel',
+    author: 'CertifyO Contributor',
+  },
+  {
+    id: '7',
+    title: 'Next.js is Awesome',
+    slug: 'nextjs-awesome',
+    description: 'Why I love working with Next.js and React for modern web apps.',
+    content: 'Content for Next.js article...',
+    date: 'October 28, 2023',
+    category: 'Technology',
+    author: 'CertifyO Developer',
+  },
+   {
+    id: '8',
+    title: 'Delicious Recipes', // Matched title
+    slug: 'delicious-recipes', // Matched slug
+    description: 'Sharing some of my favorite recipes for everyone to enjoy.', // Matched description
+    content: 'Detailed content for delicious recipes...',
+    date: 'October 29, 2023', // Matched date
+    category: 'Food', // Matched category
+    author: 'CertifyO Chef',
+  },
+  {
+    id: '9',
+    title: 'Exploring National Parks', // Matched title
+    slug: 'national-parks', // Matched slug
+    description: 'A guide to the most beautiful national parks and hiking trails.', // Matched description
+    content: 'Detailed content for exploring national parks...',
+    date: 'October 30, 2023', // Matched date
+    category: 'Travel', // Matched category
+    author: 'CertifyO Adventurer',
+  }
+];
+
+type Props = {
+  params: { slug: string };
+};
+
+export async function generateMetadata(
+  { params }: Props,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  const slug = params.slug;
+  const post = samplePostsDataForSlugPage.find((p) => p.slug === slug);
+
+  if (!post) {
+    return {
+      title: 'Post Not Found | CertifyO Blog',
+      description: 'The blog post you are looking for does not exist.',
+    };
+  }
+
+  return {
+    title: `${post.title} | CertifyO Blog`,
+    description: post.description,
+    // openGraph: { // Example for Open Graph data
+    //   title: post.title,
+    //   description: post.description,
+    //   // images: [{ url: post.imageUrl || '/default-og-image.png' }],
+    // },
+  };
+}
+
+export default function BlogPostLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/blog/[slug]/layout.tsx
+++ b/src/app/blog/[slug]/layout.tsx
@@ -115,7 +115,7 @@ type Props = {
 
 export async function generateMetadata(
   { params }: Props,
-  parent: ResolvingMetadata
+  _parent: ResolvingMetadata // Changed parent to _parent
 ): Promise<Metadata> {
   const slug = params.slug;
   const post = samplePostsDataForSlugPage.find((p) => p.slug === slug);
@@ -140,8 +140,12 @@ export async function generateMetadata(
 
 export default function BlogPostLayout({
   children,
+  params,
 }: {
   children: React.ReactNode;
+  params: { slug: string };
 }) {
+  // params can be used here if needed, e.g. for context providers
+  // console.log('Blog Post Layout Params:', params);
   return <>{children}</>;
 }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import React, { useState, useEffect } from 'react'; // Added useState, useEffect
+import React, { useState, useEffect } from 'react';
 import { useParams } from 'next/navigation';
-import type { Metadata, ResolvingMetadata } from 'next';
-import Link from 'next/link'; // Added Link for breadcrumbs/back button
-import { ArrowLeft, CalendarDays, Tag } from 'lucide-react'; // Icons
+// Removed Metadata imports, as generateMetadata is being moved
+import Link from 'next/link';
+import { ArrowLeft, CalendarDays, Tag } from 'lucide-react';
 
 interface BlogPost {
   title: string;
@@ -12,10 +12,12 @@ interface BlogPost {
   slug: string;
   category?: string;
   content: string;
-  date?: string; // Optional date field
+  date?: string;
 }
 
-const samplePostsDataForSlugPage: BlogPost[] = [
+// This data is now for the page component's rendering purposes only.
+// Metadata generation will use its own data source in the layout.tsx.
+const postDisplayData: BlogPost[] = [
   {
     title: 'My First Blog Post',
     description: 'This is the description for my first blog post about web development.',
@@ -132,37 +134,14 @@ const samplePostsDataForSlugPage: BlogPost[] = [
   }
 ];
 
-type Props = {
-  params: { slug: string };
-};
-
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  const slug = params.slug;
-  const post = samplePostsDataForSlugPage.find((p) => p.slug === slug);
-
-  if (!post) {
-    return {
-      title: 'Post Not Found | CertifyO Blog',
-      description: 'The blog post you are looking for could not be found.',
-    };
-  }
-
-  return {
-    title: `${post.title} | CertifyO Blog`,
-    description: post.description,
-  };
-}
-
+// Removed generateMetadata function and its specific data array.
+// Metadata will be handled by src/app/blog/[slug]/layout.tsx.
 
 export default function BlogPostPage() {
   const params = useParams();
   const slug = params?.slug as string;
-  const [isDarkMode, setIsDarkMode] = useState(false); // Basic dark mode state
+  const [isDarkMode, setIsDarkMode] = useState(false);
 
-  // Simulate theme store for styling consistency
    useEffect(() => {
     const matcher = window.matchMedia('(prefers-color-scheme: dark)');
     setIsDarkMode(matcher.matches);
@@ -171,7 +150,8 @@ export default function BlogPostPage() {
     return () => matcher.removeEventListener('change', listener);
   }, []);
 
-  const post = samplePostsDataForSlugPage.find((p) => p.slug === slug);
+  // The page component now uses 'postDisplayData' for its rendering needs.
+  const post = postDisplayData.find((p) => p.slug === slug);
 
   if (!post) {
     return (

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import React, { useState, useEffect } from 'react'; // Added useState, useEffect
+import { useParams } from 'next/navigation';
+import type { Metadata, ResolvingMetadata } from 'next';
+import Link from 'next/link'; // Added Link for breadcrumbs/back button
+import { ArrowLeft, CalendarDays, Tag } from 'lucide-react'; // Icons
+
+interface BlogPost {
+  title: string;
+  description: string;
+  slug: string;
+  category?: string;
+  content: string;
+  date?: string; // Optional date field
+}
+
+const samplePostsDataForSlugPage: BlogPost[] = [
+  {
+    title: 'My First Blog Post',
+    description: 'This is the description for my first blog post about web development.',
+    slug: 'first-post',
+    category: 'Technology',
+    date: 'October 26, 2023',
+    content: `
+      This is the full content of my first blog post. It's a great starting point for my blogging journey.
+      I plan to write about various topics, including web development, technology, and perhaps some personal interests.
+
+      ## Subheading for First Post
+      Here's a little more detail under a subheading. Content can be structured using Markdown-like conventions.
+      We can even include some basic HTML like <strong>strong text</strong> or <em>emphasized text</em>.
+
+      <p>Paragraphs are rendered well when using line breaks, which are converted to br tags in this example. For more structured content, consider using a Markdown-to-HTML converter and proper typography settings.</p>
+
+      <pre><code class="language-javascript">function greet() {\n  console.log("Hello, World!");\n}</code></pre>
+
+      <blockquote>This is a blockquote, useful for highlighting important information or quotes from other sources. It should stand out visually.</blockquote>
+
+      Stay tuned for more updates!
+    `,
+  },
+  {
+    title: 'Another Interesting Article',
+    description: 'A brief overview of an interesting topic in the world of travel.',
+    slug: 'interesting-article',
+    category: 'Travel',
+    date: 'October 27, 2023',
+    content: `
+      This article delves into a fascinating subject that has been on my mind lately regarding global travel trends.
+      It explores how backpacking has changed in the last decade and what new adventurers can expect.
+
+      ### Key Travel Insights
+      - Always pack light.
+      - Learn a few phrases in the local language.
+      - Be open to spontaneous detours.
+
+      <p>Travel broadens the mind, they say. And it's true! Getting out of your comfort zone is where real growth happens.</p>
+
+      Further research into specific destinations is encouraged if this piques your interest.
+    `,
+  },
+  {
+    title: 'Next.js is Awesome',
+    description: 'Why I love working with Next.js and React for modern web apps.',
+    slug: 'nextjs-awesome',
+    category: 'Technology',
+    date: 'October 28, 2023',
+    content: `
+      Next.js has revolutionized the way I build web applications. Its features like server-side rendering,
+      static site generation, and easy routing make development a breeze.
+
+      Working with React components within the Next.js framework is incredibly productive.
+      I particularly appreciate:
+      <ul>
+        <li>The file-system based routing.</li>
+        <li>API routes for backend functionality.</li>
+        <li>Built-in Image optimization.</li>
+        <li>Fast refresh for a great developer experience.</li>
+      </ul>
+
+      <p>If you haven't tried Next.js yet for your React projects, I highly recommend it! It simplifies so many common complexities in web development.</p>
+    `,
+  },
+  {
+    title: 'Delicious Recipes',
+    description: 'Sharing some of my favorite recipes for everyone to enjoy.',
+    slug: 'delicious-recipes',
+    category: 'Food',
+    date: 'October 29, 2023',
+    content: `
+      Today, I'm sharing a recipe for a simple yet delicious pasta dish.
+      It's quick to make and perfect for a weeknight dinner.
+
+      #### Ingredients:
+      - Pasta of your choice
+      - Olive oil
+      - Garlic
+      - Cherry tomatoes
+      - Fresh basil
+      - Parmesan cheese (optional)
+
+      #### Instructions:
+      1. Cook pasta according to package directions.
+      2. While pasta cooks, heat olive oil in a pan, add minced garlic.
+      3. Add halved cherry tomatoes and cook until they soften.
+      4. Drain pasta, toss with tomato mixture and fresh basil.
+      5. Serve with Parmesan if desired.
+
+      Bon appétit!
+    `,
+  },
+  {
+    title: 'Exploring National Parks',
+    description: 'A guide to the most beautiful national parks and hiking trails.',
+    slug: 'national-parks',
+    category: 'Travel',
+    date: 'October 30, 2023',
+    content: `
+      National Parks offer a stunning escape into nature. This guide highlights a few must-visit parks.
+
+      ##### Yellowstone
+      Famous for its geysers and wildlife. Don't miss Old Faithful!
+
+      ##### Yosemite
+      Known for its giant sequoia trees, breathtaking waterfalls, and granite cliffs like El Capitan.
+
+      ##### Grand Canyon
+      A truly awe-inspiring geological wonder. Hiking down (even partway) is an unforgettable experience.
+
+      Remember to plan your trips, check for park alerts, and leave no trace.
+    `,
+  }
+];
+
+type Props = {
+  params: { slug: string };
+};
+
+export async function generateMetadata(
+  { params }: Props,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  const slug = params.slug;
+  const post = samplePostsDataForSlugPage.find((p) => p.slug === slug);
+
+  if (!post) {
+    return {
+      title: 'Post Not Found | CertifyO Blog',
+      description: 'The blog post you are looking for could not be found.',
+    };
+  }
+
+  return {
+    title: `${post.title} | CertifyO Blog`,
+    description: post.description,
+  };
+}
+
+
+export default function BlogPostPage() {
+  const params = useParams();
+  const slug = params?.slug as string;
+  const [isDarkMode, setIsDarkMode] = useState(false); // Basic dark mode state
+
+  // Simulate theme store for styling consistency
+   useEffect(() => {
+    const matcher = window.matchMedia('(prefers-color-scheme: dark)');
+    setIsDarkMode(matcher.matches);
+    const listener = (e: MediaQueryListEvent) => setIsDarkMode(e.matches);
+    matcher.addEventListener('change', listener);
+    return () => matcher.removeEventListener('change', listener);
+  }, []);
+
+  const post = samplePostsDataForSlugPage.find((p) => p.slug === slug);
+
+  if (!post) {
+    return (
+      <div className={`min-h-screen flex items-center justify-center px-4 ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'}`}>
+        <div className="text-center py-12">
+            <svg className={`mx-auto h-16 w-16 ${isDarkMode ? 'text-red-500' : 'text-red-600'}`} fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+            </svg>
+            <h1 className={`mt-4 text-3xl font-bold tracking-tight ${isDarkMode ? 'text-white' : 'text-gray-900'} sm:text-4xl`}>Post Not Found</h1>
+            <p className={`mt-3 text-base ${isDarkMode ? 'text-gray-300' : 'text-gray-600'}`}>Sorry, we couldn’t find the blog post you’re looking for.</p>
+            <div className="mt-8">
+              <Link href="/blog" className={`inline-flex items-center rounded-md border px-4 py-2 text-sm font-medium shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+                  isDarkMode
+                    ? 'border-gray-600 text-indigo-400 hover:bg-gray-700 focus:ring-indigo-500 focus:ring-offset-gray-800'
+                    : 'border-gray-300 text-indigo-600 hover:bg-gray-100 focus:ring-indigo-500 focus:ring-offset-white'
+                } transition-all`}>
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to Blog
+              </Link>
+            </div>
+          </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`min-h-screen ${isDarkMode ? 'bg-gray-900' : 'bg-gray-50'} transition-colors duration-300 ease-in-out`}>
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
+        <div className="mb-6">
+            <Link href="/blog" className={`inline-flex items-center text-sm font-medium ${isDarkMode ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-800'} group transition-colors duration-150 ease-in-out`}>
+              <ArrowLeft className="mr-2 h-4 w-4 transform transition-transform duration-150 ease-in-out group-hover:-translate-x-1" />
+              Back to Blog
+            </Link>
+        </div>
+
+        <article className={`p-6 sm:p-8 md:p-10 rounded-xl shadow-xl ${isDarkMode ? 'bg-gray-800 text-gray-100' : 'bg-white text-gray-900'}`}>
+          <header className="mb-6 pb-6 border-b dark:border-gray-700">
+            <h1 className={`text-3xl sm:text-4xl lg:text-5xl font-extrabold leading-tight mb-3 ${isDarkMode ? 'text-gray-50' : 'text-gray-900'}`}>
+              {post.title}
+            </h1>
+            <div className="flex flex-wrap items-center text-sm">
+              {post.category && (
+                <div className={`flex items-center mr-4 ${isDarkMode ? 'text-indigo-400' : 'text-indigo-600'}`}>
+                  <Tag className="mr-1.5 h-4 w-4" />
+                  <span className="font-medium uppercase tracking-wider">{post.category}</span>
+                </div>
+              )}
+              {post.date && (
+                <div className={`flex items-center ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                  <CalendarDays className="mr-1.5 h-4 w-4" />
+                  <span>{post.date}</span>
+                </div>
+              )}
+            </div>
+          </header>
+
+          <div
+            className={`prose prose-lg sm:prose-xl max-w-none ${isDarkMode ? 'prose-invert' : ''}
+                        prose-headings:font-bold ${isDarkMode ? 'prose-headings:text-gray-100' : 'prose-headings:text-gray-900'}
+                        prose-p:${isDarkMode ? 'text-gray-300' : 'text-gray-700'}
+                        prose-a:${isDarkMode ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-800'}
+                        prose-strong:${isDarkMode ? 'text-gray-100' : 'text-gray-900'}
+                        prose-blockquote:${isDarkMode ? 'border-l-indigo-400 text-gray-300' : 'border-l-indigo-600 text-gray-700'}
+                        prose-code:${isDarkMode ? 'bg-gray-700 text-indigo-300 p-1 rounded-md' : 'bg-gray-100 text-indigo-700 p-1 rounded-md'}
+                        prose-pre:${isDarkMode ? 'bg-gray-700' : 'bg-gray-100'}
+                        prose-ul:${isDarkMode ? 'marker:text-indigo-400' : 'marker:text-indigo-600'}
+                        prose-ol:${isDarkMode ? 'marker:text-indigo-400' : 'marker:text-indigo-600'}
+                      `}
+            dangerouslySetInnerHTML={{ __html: post.content.replace(/\n(?!(?:<ul>|<ol>|<li>|<code>|<pre>|<blockquote>|<p>|<h1>|<h2>|<h3>|<h4>|<h5>|<h6>))(\s*)(?![^<]*>)/g, '<br />') }}
+          />
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Blog | CertifyO',
+  description: 'Read our latest blog posts on technology, travel, food, and more interesting topics from the CertifyO community.',
+};
+
+export default function BlogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'; // Import card components
+import { ArrowRight } from 'lucide-react'; // For "Read More" link
+
+export const metadata: Metadata = {
+  title: 'Blog | CertifyO',
+  description: 'Read our latest blog posts on technology, travel, food, and more interesting topics from the CertifyO community.',
+};
+
+interface BlogPost {
+  title: string;
+  description:string;
+  slug: string;
+  category?: string;
+}
+
+const samplePostsData: BlogPost[] = [
+  {
+    title: 'My First Blog Post',
+    description: 'This is the description for my first blog post about web development, exploring the basics of React and Next.js.',
+    slug: 'first-post',
+    category: 'Technology',
+  },
+  {
+    title: 'Another Interesting Article',
+    description: 'A brief overview of an interesting topic in the world of travel, focusing on sustainable tourism.',
+    slug: 'interesting-article',
+    category: 'Travel',
+  },
+  {
+    title: 'Next.js is Awesome',
+    description: 'Why I love working with Next.js and React for modern web apps, covering features like SSR and SSG.',
+    slug: 'nextjs-awesome',
+    category: 'Technology',
+  },
+  {
+    title: 'Delicious Recipes for Quick Meals',
+    description: 'Sharing some of my favorite recipes for everyone to enjoy, especially when you are short on time.',
+    slug: 'delicious-recipes',
+    category: 'Food',
+  },
+  {
+    title: 'Exploring National Parks: A Hiker\'s Guide',
+    description: 'A guide to the most beautiful national parks and hiking trails, with tips for beginners and experienced hikers.',
+    slug: 'national-parks',
+    category: 'Travel',
+  }
+];
+
+const categories = ["All", "Technology", "Travel", "Food"];
+
+export default function BlogPage() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('All');
+  const [filteredPosts, setFilteredPosts] = useState<BlogPost[]>(samplePostsData);
+  const [isDarkMode, setIsDarkMode] = useState(false); // Basic dark mode state, ideally from theme store
+
+  // Simulate theme store for styling consistency
+  useEffect(() => {
+    // In a real app, this would come from useThemeStore()
+    const matcher = window.matchMedia('(prefers-color-scheme: dark)');
+    setIsDarkMode(matcher.matches);
+    const listener = (e: MediaQueryListEvent) => setIsDarkMode(e.matches);
+    matcher.addEventListener('change', listener);
+    return () => matcher.removeEventListener('change', listener);
+  }, []);
+
+
+  useEffect(() => {
+    let posts = samplePostsData;
+    if (searchTerm) {
+      posts = posts.filter(post =>
+        post.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        post.description.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+    }
+    if (selectedCategory !== 'All') {
+      posts = posts.filter(post => post.category === selectedCategory);
+    }
+    setFilteredPosts(posts);
+  }, [searchTerm, selectedCategory]);
+
+  const inputBaseClasses = "w-full px-3 py-2 border rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors duration-150 ease-in-out";
+  const lightInputClasses = "bg-white border-gray-300 placeholder-gray-400 text-gray-900";
+  const darkInputClasses = "bg-gray-700 border-gray-600 placeholder-gray-400 text-white";
+  const currentInputClasses = isDarkMode ? darkInputClasses : lightInputClasses;
+
+  return (
+    <div className={`min-h-screen ${isDarkMode ? 'bg-gray-900 text-gray-100' : 'bg-gray-50 text-gray-900'} transition-colors duration-300 ease-in-out`}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
+        <header className="mb-10 text-center">
+          <h1 className={`text-3xl md:text-4xl font-bold ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>CertifyO Blog</h1>
+        </header>
+
+        <section aria-labelledby="filter-heading" className={`max-w-3xl mx-auto mb-10 p-6 rounded-xl shadow-lg ${isDarkMode ? 'bg-gray-800' : 'bg-white'}`}>
+          <h2 id="filter-heading" className="sr-only">Filter Controls</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <div>
+              <label htmlFor="search" className={`block text-sm font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'} mb-1`}>
+                Search Posts
+              </label>
+              <input
+                type="text"
+                id="search"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                placeholder="Search by title or description..."
+                className={`${inputBaseClasses} ${currentInputClasses}`}
+              />
+            </div>
+            <div>
+              <label htmlFor="category" className={`block text-sm font-medium ${isDarkMode ? 'text-gray-300' : 'text-gray-700'} mb-1`}>
+                Filter by Category
+              </label>
+              <select
+                id="category"
+                value={selectedCategory}
+                onChange={(e) => setSelectedCategory(e.target.value)}
+                className={`${inputBaseClasses} ${currentInputClasses}`}
+              >
+                {categories.map(category => (
+                  <option key={category} value={category} className={isDarkMode ? 'bg-gray-700 text-white' : 'bg-white text-black'}>
+                    {category}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </section>
+
+        <main>
+          {filteredPosts.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
+              {filteredPosts.map((post) => (
+                <Card key={post.slug} className={`flex flex-col transition-all duration-300 ease-in-out hover:shadow-xl dark:border-gray-700 ${isDarkMode ? 'bg-gray-800 hover:border-gray-600' : 'bg-white hover:border-gray-300'}`}>
+                  <CardHeader>
+                    <CardTitle className="text-lg lg:text-xl">
+                      <Link href={`/blog/${post.slug}`} className={`hover:text-indigo-600 dark:hover:text-indigo-400 ${isDarkMode ? 'text-blue-400' : 'text-blue-600'} transition-colors duration-150 ease-in-out`}>
+                        {post.title}
+                      </Link>
+                    </CardTitle>
+                    {post.category && (
+                      <CardDescription className={`text-xs pt-1 ${isDarkMode ? 'text-gray-400' : 'text-gray-500'}`}>
+                        Category: {post.category}
+                      </CardDescription>
+                    )}
+                  </CardHeader>
+                  <CardContent className="flex-grow">
+                    <p className={`text-sm ${isDarkMode ? 'text-gray-300' : 'text-gray-700'}`}>{post.description}</p>
+                  </CardContent>
+                  <CardFooter>
+                    <Link href={`/blog/${post.slug}`} className={`flex items-center text-sm font-medium ${isDarkMode ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-800'} transition-colors duration-150 ease-in-out group`}>
+                      Read More
+                      <ArrowRight className="ml-1.5 h-4 w-4 transform transition-transform duration-150 ease-in-out group-hover:translate-x-1" />
+                    </Link>
+                  </CardFooter>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-12">
+              <svg className={`mx-auto h-12 w-12 ${isDarkMode ? 'text-gray-500' : 'text-gray-400'}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path vectorEffect="non-scaling-stroke" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
+              </svg>
+              <h3 className={`mt-2 text-lg font-medium ${isDarkMode ? 'text-white' : 'text-gray-900'}`}>No posts found</h3>
+              <p className={`mt-1 text-sm ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+                No blog posts matched your current search or filter criteria.
+              </p>
+            </div>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,14 +2,11 @@
 
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
-import type { Metadata } from 'next';
+// Removed Metadata import as it's no longer used here
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card'; // Import card components
 import { ArrowRight } from 'lucide-react'; // For "Read More" link
 
-export const metadata: Metadata = {
-  title: 'Blog | CertifyO',
-  description: 'Read our latest blog posts on technology, travel, food, and more interesting topics from the CertifyO community.',
-};
+// Removed the metadata export block
 
 interface BlogPost {
   title: string;

--- a/src/app/learning/page.tsx
+++ b/src/app/learning/page.tsx
@@ -3,11 +3,11 @@
 import React, { useState } from 'react';
 import { useThemeStore } from '@/store/themeStore';
 import { BookOpen, Video, Rocket, ArrowRight } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+// Removed unused useRouter import
 
 export default function LearningPage() {
   const isDarkMode = useThemeStore(state => state.isDarkMode);
-  const router = useRouter();
+  // Removed unused router variable
   const [email, setEmail] = useState('');
 
   const handleJoinWaitlist = (e: React.FormEvent) => {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -28,9 +28,9 @@ export default function Hero() {
       <div className="absolute inset-0 overflow-hidden">
 
         {/* Floating dots pattern */}
-        {Array.from({ length: 30 }).map((_, i) => (
+        {Array.from({ length: 30 }).map((_, _i) => ( // Changed i to _i
           <motion.div
-            // key={i}
+            // key={_i} // If key were to use index, it would be _i
             key={crypto.randomUUID()}
             className={`absolute rounded-full ${isDarkMode ? 'bg-indigo-900/30' : 'bg-indigo-100/70'}`}
             style={{

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import {
   User, Award, BookOpen, Sun, Moon, Menu, X as XIcon, LogOut,
-  Settings, AlignCenterVertical as Certificate,   Video, Trophy
+  Settings, AlignCenterVertical as Certificate,   Video, Trophy, Newspaper
 } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useThemeStore } from '../store/themeStore';
@@ -111,6 +111,18 @@ export default function Navigation() {
               >
                 <Video className="h-5 w-5" />
                 <span className="text-sm lg:text-base font-medium">Learning</span>
+              </Link>
+
+              <Link
+                href="/blog"
+                className={`flex items-center space-x-1 transition-all duration-200 px-3 py-2 rounded-md ${
+                  isDarkMode
+                    ? 'hover:bg-gray-800 hover:text-indigo-400'
+                    : 'hover:bg-gray-50 hover:text-indigo-600'
+                }`}
+              >
+                <Newspaper className="h-5 w-5" />
+                <span className="text-sm lg:text-base font-medium">Blog</span>
               </Link>
 
               <div className="relative" ref={eventDropdownRef}>
@@ -322,6 +334,17 @@ export default function Navigation() {
               >
                 <Video className="h-5 w-5 mr-3" />
                 <span className="font-medium">Learning</span>
+              </Link>
+
+              <Link
+                href="/blog"
+                className={`flex items-center py-3 px-4 rounded-md transition-all duration-200 ${
+                  isDarkMode ? 'hover:bg-gray-800 text-gray-100' : 'hover:bg-gray-50 text-gray-900'
+                }`}
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                <Newspaper className="h-5 w-5 mr-3" />
+                <span className="font-medium">Blog</span>
               </Link>
               
               <div className="relative">


### PR DESCRIPTION
This commit introduces a new blog section to the website.

Key features include:
- A main blog page (`/blog`) displaying a list of posts with titles, descriptions, and categories.
- Individual blog post pages (`/blog/[slug]`) for reading full articles.
- Search functionality on the blog page to filter posts by title or description.
- Category filtering on the blog page.
- SEO-friendly implementation with dynamic meta tags (title, description) for both the blog list and individual post pages.
- Semantic HTML structure for improved accessibility and SEO.
- Styling consistent with the existing website design, including dark mode support.
- Responsive design for various screen sizes.

The blog posts and categories are currently hardcoded. Future work could involve integrating a CMS or using Markdown files for content management.